### PR TITLE
requires the fileutils library

### DIFF
--- a/lib/hosts_updater.rb
+++ b/lib/hosts_updater.rb
@@ -1,6 +1,7 @@
 require 'hosts'
 require 'logger'
 require 'open-uri'
+require 'fileutils'
 
 class HostsUpdater
 


### PR DESCRIPTION
FileUtils is a required dependency, and on my machine the hosts-update script failed until the library was explicitly require'd
